### PR TITLE
updated gophermap links to be relative for easier sharing publically

### DIFF
--- a/moku-pona
+++ b/moku-pona
@@ -21,6 +21,7 @@ use URI;
 # in this directory, eg. 'alexschroeder.ch:70'. We need this because we need to
 # detect changes. We cannot rely on feeds.
 our $data_dir = ($ENV{HOME} || $ENV{LOGDIR}) . '/.moku-pona';
+our $site_root = '' || $data_dir; # $site_root = '/moku-pona' as example
 
 # This is a gopher map listing all the pages being watched whih means that you
 # can view using a gopher client. Or you can add it to your gopher site for
@@ -299,7 +300,7 @@ sub do_update {
     next unless defined $new;
     $selector =~ s/\//-/g;
     my $cache = "$data_dir/$host-$port-$selector.txt";
-    my $relsel = "$host-$port-$selector.txt";
+    my $relsel = "$site_root/$host-$port-$selector.txt";
     if ($new =~ /^<\?xml/) {
       $new = to_gopher($new);
       $line = join("\t", '1' . $desc, $relsel, "", "");

--- a/moku-pona
+++ b/moku-pona
@@ -299,9 +299,10 @@ sub do_update {
     next unless defined $new;
     $selector =~ s/\//-/g;
     my $cache = "$data_dir/$host-$port-$selector.txt";
+    my $relsel = "$host-$port-$selector.txt";
     if ($new =~ /^<\?xml/) {
       $new = to_gopher($new);
-      $line = join("\t", '1' . $desc, $cache, "", "");
+      $line = join("\t", '1' . $desc, $relsel, "", "");
     }
     my $old = load_file($cache);
     if ($new ne $old) {


### PR DESCRIPTION
If you share your updates.txt file publically on a gopher server, the filesystem underneath will not be reflected in the paths generated to the gophermaps for RSS feeds. Local browsing via VF1 of updates.txt is unaffected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kensanata/moku-pona/5)
<!-- Reviewable:end -->
